### PR TITLE
move readme description to the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # foodsharing light
 
+A mobile-friendly frontend for foodsharing.de.
+Focused on the tasks you need to do _now_!
 
 [![Build Status](https://travis-ci.org/foodsharing-dev/foodsharing-light.svg?branch=master)](https://travis-ci.org/foodsharing-dev/foodsharing-light)
 [![codecov](https://codecov.io/gh/foodsharing-dev/foodsharing-light/branch/master/graph/badge.svg)](https://codecov.io/gh/foodsharing-dev/foodsharing-light)
 [![Greenkeeper badge](https://badges.greenkeeper.io/foodsharing-dev/foodsharing-light.svg)](https://greenkeeper.io/)
-
-A mobile-friendly frontend for foodsharing.de.
-Focused on the tasks you need to do _now_!
 
 ## Build Setup
 


### PR DESCRIPTION
doing so will make it appear as the search engine page summary instead of the badges source code.