### PR TITLE
Remove csp

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,6 @@
     <link rel="icon" type="image/png" href="statics/favicon.png">
     <link rel="apple-touch-icon" href="statics/favicon.png">
 
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
     <meta name="referrer" content="no-referrer">
     <meta name="format-detection" content="telephone=no">
     <meta name="msapplication-tap-highlight" content="no">

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -52,7 +52,7 @@ export default {
     return axios.get(`/api/v1/conversations/${id}/`).then(({ data: conversation }) => {
       conversationDecodeHtmlEntities(conversation)
       let usersById = {}
-      conversation.members.forEach(({ user }) => {
+      conversation.members.forEach(user => {
         usersById[user.id] = user
       })
       conversation.messages.forEach(message => {

--- a/test/unit/specs/services/api.spec.js
+++ b/test/unit/specs/services/api.spec.js
@@ -50,7 +50,7 @@ describe('services/api', () => {
       mock.onGet('/api/v1/conversations/1/').reply(200, {
         id: 1,
         members: [
-          { user: { id: 'user1', firstName: 'user1' } }
+          { id: 'user1', firstName: 'user1' }
         ],
         messages: [
           {


### PR DESCRIPTION
@derhuerst I removed the CSP header as it breaks dev, webpack is using `eval()` - it would be nice to have the CSP headers, but will need another way.

The [html-webpack-template](https://github.com/jaketrent/html-webpack-template#basic-usage) does actually support passing in an object to create meta fields from, but the CSP meta needs a `http-equiv` attribute.

Another option would be using an ejs template and then you can access any custom options passed in, and check for production env.

I'll just remove it for now though.