### PR TITLE
Fix socket message body escaping

### DIFF
--- a/src/pages/Chat.vue
+++ b/src/pages/Chat.vue
@@ -17,7 +17,7 @@
         <div class="chat-message">
           <p>
             <strong v-if="isMultiChat">{{ message.sentBy.firstName }}<br></strong>
-            <span v-html="message.escapedBody"></span>
+            <span v-html="message.formattedBody"></span>
           </p>
         </div>
       </div>

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,5 +1,6 @@
 import Axios from 'axios'
-import { decodeHtmlEntities, escape, autolink } from 'services/stringUtils'
+import { decodeHtmlEntities } from 'services/stringUtils'
+import { formatMessage } from 'services/chat'
 import camelCase from 'camelcase'
 
 export const axios = Axios.create({
@@ -98,18 +99,20 @@ export function setPickupId (pickup) {
 }
 
 export function conversationPrepare (conversation) {
+  // We remove htmlentities (undoing how they are stored on the server)
+  // Then add our custom formatted version
   if (conversation.messages) {
-    conversation.messages.forEach(message => {
-      // sanitize and autolink. linebreaks are done via CSS
-      // https://gitlab.com/foodsharing-dev/foodsharing/blob/0fbbbac4322cd824378dc007e77e6dbd0e9adf3e/app/msg/msg.script.js#L419
-      message.escapedBody = autolink(escape(decodeHtmlEntities(message.body)))
-      delete message.body
-    })
+    conversation.messages.forEach(messageDecodeHtmlEntities)
+    conversation.messages.forEach(formatMessage)
   }
   if (conversation.lastMessage) {
-    // this is the preview, the UI doesn't support formatting
-    conversation.lastMessage.body = decodeHtmlEntities(conversation.lastMessage.body)
+    messageDecodeHtmlEntities(conversation.lastMessage)
+    formatMessage(conversation.lastMessage)
   }
+}
+
+export function messageDecodeHtmlEntities (message) {
+  message.body = decodeHtmlEntities(message.body)
 }
 
 export function isObject (x) {

--- a/src/services/chat.js
+++ b/src/services/chat.js
@@ -2,6 +2,7 @@ import Vue from 'vue'
 
 import foodsharing from 'services/foodsharing'
 import api from 'services/api'
+import { escape, autolink } from 'services/stringUtils'
 
 export const state = {
 
@@ -48,6 +49,7 @@ export default {
   },
 
   receiveMessage (message) {
+    formatMessage(message)
     let { conversationId } = message
     let conversation = state.conversations[conversationId]
     if (conversation) {
@@ -68,4 +70,10 @@ export default {
     return Promise.resolve()
   }
 
+}
+
+export function formatMessage (message) {
+  // sanitize and autolink. linebreaks are done via CSS
+  // safe to output directly to html
+  message.formattedBody = autolink(escape(message.body))
 }

--- a/test/unit/specs/pages/Chat.spec.js
+++ b/test/unit/specs/pages/Chat.spec.js
@@ -1,0 +1,86 @@
+import Vue from 'vue'
+import VueRouter from 'vue-router'
+
+import Chat from 'pages/Chat'
+import api from 'services/api'
+import auth from 'services/auth'
+
+const sandbox = sinon.sandbox.create()
+
+const router = new VueRouter({
+  routes: []
+})
+
+describe('pages/Chat.vue', () => {
+  let vm
+
+  afterEach(() => sandbox.restore())
+
+  describe('with chats', () => {
+    let user1 = {
+      id: 30,
+      firstName: 'user1'
+    }
+    let user2 = {
+      id: 31,
+      firstName: 'user2'
+    }
+
+    beforeEach(() => {
+      auth.state.user = user1
+      sandbox.stub(api, 'getConversation').resolves({
+        id: 10,
+        members: [user1, user2],
+        messages: [
+          {
+            id: 20,
+            sentAt: '2017-08-14T10:42:42.960Z',
+            sentBy: user1,
+            body: 'hello',
+            formattedBody: 'hello'
+          },
+          {
+            id: 21,
+            sentAt: '2017-08-14T10:42:42.960Z',
+            sentBy: user2,
+            body: 'hey',
+            formattedBody: 'hey'
+          }
+        ]
+      })
+      vm = new Vue({ ...Chat, router }).$mount()
+      return Vue.nextTick().then(() => Vue.nextTick())
+    })
+
+    it('calls api and sets the conversation data', () => {
+      expect(api.getConversation).to.have.been.called
+      expect(vm.conversation).to.not.be.null
+      expect(vm.conversation.messages.length).to.equal(2)
+    })
+
+    it('renders a list of messages', () => {
+      expect(vm.conversation.messages.length).to.equal(2)
+      expect(vm.$el.querySelectorAll('.chat-message').length).to.equal(2)
+    })
+
+    it('renders the expected content', () => {
+      expect(vm.$el.textContent).to.contain('hello')
+      expect(vm.$el.textContent).to.contain('hey')
+      expect(vm.$el.textContent).to.not.contain(user1.firstName)
+      expect(vm.$el.textContent).to.not.contain(user2.firstName)
+    })
+
+    it('updates when new message added', () => {
+      vm.conversation.messages.push({
+        id: 22,
+        sentAt: '2017-08-14T10:42:42.960Z',
+        sentBy: user2,
+        body: 'a new message',
+        formattedBody: 'a new message'
+      })
+      return Vue.nextTick().then(() => {
+        expect(vm.$el.textContent).to.contain('a new message')
+      })
+    })
+  })
+})

--- a/test/unit/specs/services/api.spec.js
+++ b/test/unit/specs/services/api.spec.js
@@ -85,8 +85,8 @@ describe('services/api', () => {
         ]
       })
       return api.getConversation(1).then(conversation => {
-        expect(conversation.messages[0].escapedBody).to.equal('love &amp; radio')
-        expect(conversation.messages[0].body).to.be.undefined
+        expect(conversation.messages[0].formattedBody).to.equal('love &amp; radio')
+        expect(conversation.messages[0].body).to.equal('love & radio')
       })
     })
   })

--- a/test/unit/specs/services/chat.spec.js
+++ b/test/unit/specs/services/chat.spec.js
@@ -21,7 +21,7 @@ describe('services/chat', () => {
       sentAt: 'foo'
     }
 
-    let escapedMessage = {
+    let formattedMessage = {
       ...message,
       formattedBody: 'a nice message body!'
     }
@@ -37,7 +37,7 @@ describe('services/chat', () => {
       it('adds new message to conversation', () => {
         return chat.receiveMessage(message).then(() => {
           expect(chat.state.conversations[1].messages.length).to.equal(1)
-          expect(chat.state.conversations[1].messages[0]).to.deep.equal(escapedMessage)
+          expect(chat.state.conversations[1].messages[0]).to.deep.equal(formattedMessage)
         })
       })
 

--- a/test/unit/specs/services/chat.spec.js
+++ b/test/unit/specs/services/chat.spec.js
@@ -17,13 +17,13 @@ describe('services/chat', () => {
   describe('receiveMessage', () => {
     let message = {
       conversationId: 1,
-      body: 'a nice message & body!',
+      body: 'a nice message body!',
       sentAt: 'foo'
     }
 
     let escapedMessage = {
       ...message,
-      escapedBody: 'a nice message &amp; body!'
+      formattedBody: 'a nice message body!'
     }
 
     describe('conversation map', () => {

--- a/test/unit/specs/services/chat.spec.js
+++ b/test/unit/specs/services/chat.spec.js
@@ -17,8 +17,13 @@ describe('services/chat', () => {
   describe('receiveMessage', () => {
     let message = {
       conversationId: 1,
-      body: 'a nice message body!',
+      body: 'a nice message & body!',
       sentAt: 'foo'
+    }
+
+    let escapedMessage = {
+      ...message,
+      escapedBody: 'a nice message &amp; body!'
     }
 
     describe('conversation map', () => {
@@ -32,7 +37,7 @@ describe('services/chat', () => {
       it('adds new message to conversation', () => {
         return chat.receiveMessage(message).then(() => {
           expect(chat.state.conversations[1].messages.length).to.equal(1)
-          expect(chat.state.conversations[1].messages[0]).to.deep.equal(message)
+          expect(chat.state.conversations[1].messages[0]).to.deep.equal(escapedMessage)
         })
       })
 


### PR DESCRIPTION
@tiltec the changes I merged forgot the case of messages coming from the websocket, so existing messages would render ok, but any new messages would be rendered as an empty chat bubble (as it didn't not have `escapedBody` field).

I added tests, but also changed things around a little bit:
- seperated the step of decoding the encoded entities in the db (should _always_ happen for all messages), from applying our formatting (happens selectively, depending on where/how it will be displayed)
- no longer delete the unformatted body (as we keep a reference to messages as the `lastMessage` field where we use that field)
- rename to `formattedBody` to capture that it is doing more than just escaping it